### PR TITLE
Break dependency on running script as root via crontab

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ just some basic nagios plugin
 # /usr/lib/nagios/plugins/check_zfs # one pool
 OK storage-02(ONLINE 10.3T/87T),storage-03(ONLINE 75.6T/87T),storage-81(ONLINE 1.00T/87T)
 # resilver example
-WARNING storage-02(ONLINE 11.1T/87T),storage-03(RESILVER 18.53%,223M/s,82h51m),storage-81(ONLINE 1.00T/87T) 
+WARNING storage-02(ONLINE 11.1T/87T),storage-03(RESILVER 18.53%,223M/s,82h51m),storage-81(ONLINE 1.00T/87T)
 # /usr/lib/nagios/plugins/check_zfs # multiple storage pool
 OK storage-03(ONLINE 118T/390T)
 ```
@@ -18,6 +18,36 @@ OK storage-03(ONLINE 118T/390T)
 * * * * * root /usr/bin/perl /usr/lib/nagios/plugins/check_zfs |xargs echo $(hostname) pass_Raid| xargs passive_check_send
 ```
 
+#### integrating with NRPE
+The Nagios Remote Plugin Executor can run this script upon request from a Nagios
+monitor server. The NRPE daemon runs as an unprivileged user (typically named
+`nrpe` or `nagios`) although the zfs/zpool commands require superuser privileges.
+
+Included is an example configuration file that can be placed in `/etc/sudoers.d'.
+It will allow any non-root user to run the "read-only" `zfs` and `zpool` commands
+while preventing the execution of commands that modify filesystems and storage
+pools.
+
+A typical NRPE configuration files is placed in `/etc/nrpe.d` on RHEL-derived
+platforms and `/etc/nagios/nrpe.d` on Debian derivatives. These files point to
+nagios plugins for execution. For example
+```
+command[check_zpool]=/usr/lib/nagios/plugins/check_zpool
+```
+On RHEL derivatives, the plugins are stored under `/usr/lib64`. The nagios
+monitor must then be configured to check the host using this command. The
+example below is not exact but intended to provide the outline. Please
+examine [nagios documentation](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/objectdefinitions.html)
+for the full range of nagios object definitions and their options.
+```
+define service {
+  use                    generic-service
+  service_description    zpool-health
+  hostgroup_name         storage
+  ...
+  check_command          check_nrpe_1arg!check_zpool
+}
+```
 ### Check open filehandles (comparing open filehandles with proc's rlimit nofile) - linux only
 /usr/lib/nagios/plugins/check_procs_fh [-w warningpercent] [-c criticalpercent]
 

--- a/zfs/check_zfs
+++ b/zfs/check_zfs
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use English;
 
 $ENV{'PATH'} = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
@@ -14,7 +15,8 @@ my @zpool = ();
 
 sub get_pools() {
     local *P;
-    open(P, "zpool list -H 2>&1 |") or &nagios_response("Could not find zpool command", N_CRITICAL);
+    my $zpool_cmd = $EUID == 0 ? "zpool" : "sudo zpool";
+    open(P, $zpool_cmd . " list -H 2>&1 |") or &nagios_response("Could not find zpool command", N_CRITICAL);
     while (<P>) {
 	chomp;
 	my @ret = split(/\s+/, $_);
@@ -39,7 +41,8 @@ sub get_status()
     my $cat = 0;
     my $res = {};
     local *P;
-    open(P, "zpool status $storage 2>&1 |") or &nagios_response("Could not find zpool command", N_CRITICAL);
+    my $zpool_cmd = $EUID == 0 ? "zpool" : "sudo zpool";
+    open(P, $zpool_cmd . " status $storage 2>&1 |") or &nagios_response("Could not find zpool command", N_CRITICAL);
 	while (<P>) {
 	    chomp;
 	    if ($_ =~ /^\s*([^\s]+):\s*(.*)$/) {

--- a/zfs/sudoers.d/zfs
+++ b/zfs/sudoers.d/zfs
@@ -1,0 +1,30 @@
+# CAUTION: Any syntax error introduced here will break sudo
+# for all use cases.
+
+# Allow sudo to be run without a tty session (via nrpe)
+Defaults    !requiretty
+
+# Allow read-only ZoL commands to be called through sudo
+# without a password.
+Cmnd_Alias C_ZFS = \
+  /sbin/zfs "", /sbin/zfs help *, \
+  /usr/sbin/zfs "", /usr/sbin/zfs help *, \
+  /sbin/zfs get, /sbin/zfs get *, \
+  /usr/sbin/zfs get, /usr/sbin/zfs get *, \
+  /sbin/zfs list, /sbin/zfs list *, \
+  /usr/sbin/zfs list, /usr/sbin/zfs list *, \
+  /sbin/zpool "", /sbin/zpool help *, \
+  /usr/sbin/zpool "", /usr/sbin/zpool help *, \
+  /sbin/zpool iostat, /sbin/zpool iostat *, \
+  /usr/sbin/zpool iostat, /usr/sbin/zpool iostat *, \
+  /sbin/zpool list, /sbin/zpool list *, \
+  /usr/sbin/zpool list, /usr/sbin/zpool list *, \
+  /sbin/zpool status, /sbin/zpool status *, \
+  /usr/sbin/zpool status, /usr/sbin/zpool status *, \
+  /sbin/zpool upgrade, /sbin/zpool upgrade -v, \
+  /usr/sbin/zpool upgrade, /usr/sbin/zpool upgrade -v
+
+Runas_Alias R_ROOT = root
+
+# allow any user to use basic read-only ZFS commands
+ALL ALL = (R_ROOT) NOPASSWD: C_ZFS


### PR DESCRIPTION
Enable use as a script run by NRPE daemon user (typically nrpe or nagios)
1. Modify script to use sudo elevation to run zpool commands
2. Add sudoers.d file that allows any user on system to run
   read-only zfs/zpool commands
