### PR TITLE
change of pool health detection

### DIFF
--- a/zfs/check_zfs
+++ b/zfs/check_zfs
@@ -22,7 +22,7 @@ sub get_pools() {
 	my @ret = split(/\s+/, $_);
 	push(@zpool, {
 	    'name'	=> $ret[0],
-	    'health'	=> $ret[8],
+	    'health'	=> $ret[-2],
 	    'size'	=> $ret[1],
 	    'alloc'	=> $ret[2],
 	    'free'	=> $ret[3]


### PR DESCRIPTION
Debian Buster added another column to ``` zpool list ``` which broke the health detection. The code is change to read the status from the right side of the string

In Ubuntu 18.04 LTS and Debian Stretch it is:
``` zfsdata 1.81T   485G    1.34T   -       45%     26%     1.00x   ONLINE  - ```

In Debian Buster it is:
``` zfsdata 1.81T   485G    1.34T   -       -       45%     26%     1.00x   ONLINE  - ```